### PR TITLE
feat(setup): improve color contrast

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -186,7 +186,7 @@ def setup(c, flavour, samecolorrows = False):
     c.hints.border = "1px solid " + palette["mantle"]
 
     ## Font color for the matched part of hints.
-    c.colors.hints.match.fg = palette["subtext1"]
+    c.colors.hints.match.fg = palette["rosewater"]
     # }}}
 
     # keyhints {{{

--- a/setup.py
+++ b/setup.py
@@ -151,9 +151,9 @@ def setup(c, flavour, samecolorrows = False):
     ## Foreground color of the selected completion item.
     c.colors.completion.item.selected.fg = palette["text"]
     ## Foreground color of the selected completion item.
-    c.colors.completion.item.selected.match.fg = palette["rosewater"]
+    c.colors.completion.item.selected.match.fg = palette["peach"]
     ## Foreground color of the matched text in the completion.
-    c.colors.completion.match.fg = palette["text"]
+    c.colors.completion.match.fg = palette["peach"]
 
     ## Color of the scrollbar in completion view
     c.colors.completion.scrollbar.bg = palette["crust"]


### PR DESCRIPTION
- feat(setup): improve `c.colors.completion` contrast
    - Using striking colors for matched items enhances perception with minimal cognitive strain. Unfortunately, `c.colors.completion.item.selected.match.fg` is no longer slightly brighter than `c.colors.completion.match.fg` because they now share the same color. This results from the strong contrast between `peach` and `maroon`.
- feat(setup): increase `c.colors.hints` contrast
    - Contrast based on `c.colors.hints.bg` and `c.colors.hints.match.fg`.
