### PR TITLE
feat(setup): improve private status bar

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -290,7 +290,7 @@ def setup(c, flavour, samecolorrows = False):
 
     ## PRIVATE MODE COLORS
     ## Background color of the statusbar in private browsing mode.
-    c.colors.statusbar.private.bg = palette["mantle"]
+    c.colors.statusbar.private.bg = palette["crust"]
     ## Foreground color of the statusbar in private browsing mode.
     c.colors.statusbar.private.fg = palette["subtext1"]
     ## Background color of the statusbar in private browsing + command mode.

--- a/setup.py
+++ b/setup.py
@@ -294,7 +294,7 @@ def setup(c, flavour, samecolorrows = False):
     ## Foreground color of the statusbar in private browsing mode.
     c.colors.statusbar.private.fg = palette["subtext1"]
     ## Background color of the statusbar in private browsing + command mode.
-    c.colors.statusbar.command.private.bg = palette["base"]
+    c.colors.statusbar.command.private.bg = palette["crust"]
     ## Foreground color of the statusbar in private browsing + command mode.
     c.colors.statusbar.command.private.fg = palette["subtext1"]
 


### PR DESCRIPTION
- feat(setup): use more distinctive `c.colors.statusbar.private.bg` color
    - Make `c.colors.statusbar.private.bg` more distinctive from `c.colors.statusbar.normal.bg` by using the darkest palet color. Bright colors are not used because they would make all other `c.colors.statusbar` properties harder to read.
- feat(setup): create coherent private status bar
    - Using the same color for `c.colors.statusbar.command.private.bg` and `c.colors.statusbar.command.bg` assures coherence with other menus, like `c.colors.completion.category.bg`. However, the overall coherence in private mode is improved by matching `c.colors.statusbar.command.private.bg` with `c.colors.statusbar.private.bg`.
