### PR TITLE
Add colors for tab indicator start/stop

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -322,6 +322,10 @@ def setup(c, flavour, samecolorrows = False):
     ##	 - hsl: Interpolate in the HSL color system.
     ##	 - none: Don't show a gradient.
     c.colors.tabs.indicator.system = "none"
+    ## Color gradient start for the tab indicator.
+    c.colors.tabs.indicator.start = palette["blue"]
+    ## Color gradient end for the tab indicator.
+    c.colors.tabs.indicator.stop = palette["green"]
 
     # ## Background color of selected even tabs.
     c.colors.tabs.selected.even.bg = palette["base"]


### PR DESCRIPTION
colors.tabs.indicator.start and colors.tabs.indicator.stop is not themed.
This pr adds settings for these two options. The color "blue" and "green" is based on the default color of the two options.