### PR TITLE
feat: no web page manipulation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -344,7 +344,3 @@ def setup(c, flavour, samecolorrows = False):
     c.colors.contextmenu.selected.bg = palette["overlay0"]
     c.colors.contextmenu.selected.fg = palette["rosewater"]
     # }}}
-
-    # background color for webpages {{{
-    c.colors.webpage.bg = palette["base"]
-    # }}}


### PR DESCRIPTION
Do not set `colors.webpage.bg`. I think that setting it results in reduced usability of some web pages.

There is a line between theming a browser and attempting to theme the world wide web. And I don't believe we should be crossing it here.